### PR TITLE
Speed up deserialization of large vectors by a factor of ten

### DIFF
--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -36,6 +36,13 @@ naiveGet' = do
 
 type V = BS.ByteString -> U.Vector Int
 
+benchGetSize :: String -> BS.ByteString -> Benchmark
+benchGetSize name bs = bgroup name
+    [ bench "U.Vector Int"                 $ nf (decode :: V) bs
+    , bench "naive U.Vector Int"           $ nf (runGet naiveGet :: V) bs
+    , bench "noinline naive U.Vector Int"  $ nf (runGet naiveGet' :: V) bs
+    ]
+
 main = defaultMain
   [ bgroup "encode"
     [ bench "U.Vector Int 3"      $ nf encode vec1
@@ -45,23 +52,11 @@ main = defaultMain
     , bench "U.Vector Int 300000" $ nf encode vec5
     ]
   , bgroup "decode"
-    [ bench "U.Vector Int 3"      $ nf (decode :: V) bs1
-    , bench "U.Vector Int 30"     $ nf (decode :: V) bs2
-    , bench "U.Vector Int 300"    $ nf (decode :: V) bs3
-    , bench "U.Vector Int 30000"  $ nf (decode :: V) bs4
-    , bench "U.Vector Int 300000" $ nf (decode :: V) bs5
-
-    , bench "naive U.Vector Int 3"      $ nf (runGet naiveGet :: V) bs1
-    , bench "naive U.Vector Int 30"     $ nf (runGet naiveGet :: V) bs2
-    , bench "naive U.Vector Int 300"    $ nf (runGet naiveGet :: V) bs3
-    , bench "naive U.Vector Int 30000"  $ nf (runGet naiveGet :: V) bs4
-    , bench "naive U.Vector Int 300000" $ nf (runGet naiveGet :: V) bs5
-
-    , bench "noinline naive U.Vector Int 3"      $ nf (runGet naiveGet' :: V) bs1
-    , bench "noinline naive U.Vector Int 30"     $ nf (runGet naiveGet' :: V) bs2
-    , bench "noinline naive U.Vector Int 300"    $ nf (runGet naiveGet' :: V) bs3
-    , bench "noinline naive U.Vector Int 30000"  $ nf (runGet naiveGet' :: V) bs4
-    , bench "noinline naive U.Vector Int 300000" $ nf (runGet naiveGet' :: V) bs5
+    [ benchGetSize "size=3" bs1
+    , benchGetSize "size=30" bs2
+    , benchGetSize "size=300" bs3
+    , benchGetSize "size=30000" bs4
+    , benchGetSize "size=300000" bs5
     ]
   ]
 

--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -1,33 +1,53 @@
 import Criterion.Main
 import Data.Binary
+import Data.Binary.Get
 
 import qualified Data.ByteString.Lazy     as BS
 import qualified Data.Vector.Unboxed as U
 import Data.Vector.Binary
 
 
-vec1,vec2,vec3 :: U.Vector Int
+vec1,vec2,vec3,vec4,vec5 :: U.Vector Int
 vec1 = U.enumFromN 0 3
 vec2 = U.enumFromN 0 30
 vec3 = U.enumFromN 0 300
+vec4 = U.enumFromN 0 30000
+vec5 = U.enumFromN 0 300000
 
-bs1,bs2,bs3 :: BS.ByteString
+bs1,bs2,bs3,bs4,bs5 :: BS.ByteString
 bs1 = encode vec1
 bs2 = encode vec2
 bs3 = encode vec3
+bs4 = encode vec4
+bs5 = encode vec5
+
+naiveGet :: (Binary a, U.Unbox a) => Get (U.Vector a)
+naiveGet = do
+    n <- get
+    U.replicateM n get
 
 type V = BS.ByteString -> U.Vector Int
 
 main = defaultMain
   [ bgroup "encode"
-    [ bench "U.Vector Int 3"   $ nf encode vec1
-    , bench "U.Vector Int 30"  $ nf encode vec2
-    , bench "U.Vector Int 300" $ nf encode vec3
+    [ bench "U.Vector Int 3"      $ nf encode vec1
+    , bench "U.Vector Int 30"     $ nf encode vec2
+    , bench "U.Vector Int 300"    $ nf encode vec3
+    , bench "U.Vector Int 30000"  $ nf encode vec4
+    , bench "U.Vector Int 300000" $ nf encode vec5
     ]
   , bgroup "decode"
-    [ bench "U.Vector Int 3"   $ nf (decode :: V) bs1
-    , bench "U.Vector Int 30"  $ nf (decode :: V) bs2
-    , bench "U.Vector Int 300" $ nf (decode :: V) bs3
+    [ bench "U.Vector Int 3"      $ nf (decode :: V) bs1
+    , bench "U.Vector Int 30"     $ nf (decode :: V) bs2
+    , bench "U.Vector Int 300"    $ nf (decode :: V) bs3
+    , bench "U.Vector Int 30000"  $ nf (decode :: V) bs4
+    , bench "U.Vector Int 300000" $ nf (decode :: V) bs5
+
+    , bench "naive U.Vector Int 3"      $ nf (runGet naiveGet :: V) bs1
+    , bench "naive U.Vector Int 30"     $ nf (runGet naiveGet :: V) bs2
+    , bench "naive U.Vector Int 300"    $ nf (runGet naiveGet :: V) bs3
+    , bench "naive U.Vector Int 30000"  $ nf (runGet naiveGet :: V) bs4
+    , bench "naive U.Vector Int 300000" $ nf (runGet naiveGet :: V) bs5
     ]
   ]
 

--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -26,6 +26,14 @@ naiveGet = do
     n <- get
     U.replicateM n get
 
+naiveGet' :: (Binary a, U.Unbox a) => Get (U.Vector a)
+naiveGet' = do
+    n <- get
+    U.replicateM n get
+-- A feeble attempt at simulating what will happen if we end up with a situation
+-- where we are unable to specialize to the element type
+{-# NOINLINE naiveGet' #-}
+
 type V = BS.ByteString -> U.Vector Int
 
 main = defaultMain
@@ -48,6 +56,12 @@ main = defaultMain
     , bench "naive U.Vector Int 300"    $ nf (runGet naiveGet :: V) bs3
     , bench "naive U.Vector Int 30000"  $ nf (runGet naiveGet :: V) bs4
     , bench "naive U.Vector Int 300000" $ nf (runGet naiveGet :: V) bs5
+
+    , bench "noinline naive U.Vector Int 3"      $ nf (runGet naiveGet' :: V) bs1
+    , bench "noinline naive U.Vector Int 30"     $ nf (runGet naiveGet' :: V) bs2
+    , bench "noinline naive U.Vector Int 300"    $ nf (runGet naiveGet' :: V) bs3
+    , bench "noinline naive U.Vector Int 30000"  $ nf (runGet naiveGet' :: V) bs4
+    , bench "noinline naive U.Vector Int 300000" $ nf (runGet naiveGet' :: V) bs5
     ]
   ]
 

--- a/vector-binary-instances.cabal
+++ b/vector-binary-instances.cabal
@@ -1,5 +1,5 @@
 Name:                vector-binary-instances
-Version:             0.2.1.1
+Version:             0.2.1.2
 Synopsis:            Instances of Data.Binary and Data.Serialize for vector
 Description:
    Instances for Binary for the types defined in the vector package,


### PR DESCRIPTION
tl;dr. the current `Get` implementation is rather slow. This speeds it up
significantly but I thought it would be appropriate to give you the opportunity
to object.

Previously the Core produced by `generateM` was quite poor. So poor, in fact,
that it would allocate a cons cell for every element it would deserialize. Take,
for instance, the STG for the inner loop of the deserializer
```hs
let {
  $s$wa1_s90Z :: Int#
              -> [Int]
              -> State# s1_a61e
              -> (# State# s1_a61e, Int #) =
      sat-only \r srt:SRT:[] [sc_s910 sc1_s911 sc2_s912]
          case sc1_s911 of
          _
          { [] ->
                let {
                  sat_s914 :: Int = NO_CCS I#! [sc_s910];
                } in 
                  (#,#) [sc2_s912 sat_s914];

            : x2_s915 xs1_s916 ->
                case x2_s915 of _
                { I# x#1_s918 ->
                      case writeIntArray# [ipv1_s90Y sc_s910 x#1_s918 sc2_s912]
                      of s'#_s919
                      { __DEFAULT ->
                            case +# [sc_s910 1]
                            of sat_s91a
                            { __DEFAULT -> $s$wa1_s90Z sat_s91a xs1_s916 s'#_s919; };
                      };
                };
          };
} in 
  case
      $s$wa1_s90Z 0 a3_s90M ipv_s90X
  of ...
```
Yes, that is a cons list there. The C-- this produces is about as bad as you
would expect.

The new implementation appears to be free of any allocation and in the case of
unboxed vectors of `Int`s, performs significantly better,

| N   | Before        | After               |
| --- | ------------- | ------------------- |
| 3   | 368 ± 73ns    | 335 ± 60ns          |
| 30  | 1.5 ± 0.350μs | 1.3 ± 0.17μs        |
| 300 | 10.0 ± 1μs    | 8.7 us ± 1μs        |
| 3e4 | 6.1 ± 0.6ms   | 980μs ± 144μs       |
| 3e5 | 80 ± 4.2ms    | 8.2 ± 1ms           | 

Instead of trying to convince vector's stream fusion framework to produce
reasonable code here I simply rewrote the serializer as the imperative loop that
we want. While the code is clearly deeply unsafe, the Core that is produced is
correct on 7.10.3, 7.8.4, and 8.0.1. Moreover, it performs equivalently to the
old implementation on small inputs and nearly an order of magnitude faster on
large (e.g. 300000 elements) inputs.
