### PR TITLE
Fix compilation of benchmarks

### DIFF
--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -1,6 +1,7 @@
 import Criterion.Main
 import Data.Binary
 import Data.Binary.Get
+import Data.Binary.Put
 
 import qualified Data.ByteString.Lazy     as BS
 import qualified Data.Vector.Unboxed as U
@@ -15,11 +16,11 @@ vec4 = U.enumFromN 0 30000
 vec5 = U.enumFromN 0 300000
 
 bs1,bs2,bs3,bs4,bs5 :: BS.ByteString
-bs1 = encode vec1
-bs2 = encode vec2
-bs3 = encode vec3
-bs4 = encode vec4
-bs5 = encode vec5
+bs1 = encodeVector vec1
+bs2 = encodeVector vec2
+bs3 = encodeVector vec3
+bs4 = encodeVector vec4
+bs5 = encodeVector vec5
 
 naiveGet :: (Binary a, U.Unbox a) => Get (U.Vector a)
 naiveGet = do
@@ -36,20 +37,23 @@ naiveGet' = do
 
 type V = BS.ByteString -> U.Vector Int
 
+encodeVector :: U.Vector Int -> BS.ByteString
+encodeVector = runPut . genericPutVector
+
 benchGetSize :: String -> BS.ByteString -> Benchmark
 benchGetSize name bs = bgroup name
-    [ bench "U.Vector Int"                 $ nf (decode :: V) bs
-    , bench "naive U.Vector Int"           $ nf (runGet naiveGet :: V) bs
-    , bench "noinline naive U.Vector Int"  $ nf (runGet naiveGet' :: V) bs
+    [ bench "U.Vector Int"                 $ nf (runGet genericGetVector :: V) bs
+    , bench "naive U.Vector Int"           $ nf (runGet naiveGet         :: V) bs
+    , bench "noinline naive U.Vector Int"  $ nf (runGet naiveGet'        :: V) bs
     ]
 
 main = defaultMain
   [ bgroup "encode"
-    [ bench "U.Vector Int 3"      $ nf encode vec1
-    , bench "U.Vector Int 30"     $ nf encode vec2
-    , bench "U.Vector Int 300"    $ nf encode vec3
-    , bench "U.Vector Int 30000"  $ nf encode vec4
-    , bench "U.Vector Int 300000" $ nf encode vec5
+    [ bench "U.Vector Int 3"      $ nf encodeVector vec1
+    , bench "U.Vector Int 30"     $ nf encodeVector vec2
+    , bench "U.Vector Int 300"    $ nf encodeVector vec3
+    , bench "U.Vector Int 30000"  $ nf encodeVector vec4
+    , bench "U.Vector Int 300000" $ nf encodeVector vec5
     ]
   , bgroup "decode"
     [ benchGetSize "size=3" bs1


### PR DESCRIPTION
This implements Edward Yang's advice in https://github.com/haskell/cabal/issues/3366, which is to remove the direct use of the instances in `Data.Vector.Binary` in the benchmark suite so as to avoid pseudo-overlapping instances.

Fixes #7.