### PR TITLE
Allow building with older versions of binary

### DIFF
--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 import Criterion.Main
 import Data.Binary
 import Data.Binary.Get
@@ -6,6 +8,15 @@ import Data.Binary.Put
 import qualified Data.ByteString.Lazy     as BS
 import qualified Data.Vector.Unboxed as U
 import Data.Vector.Binary
+
+#if !(MIN_VERSION_bytestring(0,10,0))
+import Control.DeepSeq (NFData(..))
+import qualified Data.ByteString.Lazy.Internal as BS
+
+instance NFData BS.ByteString where
+    rnf BS.Empty       = ()
+    rnf (BS.Chunk _ b) = rnf b
+#endif
 
 -- We take care to avoid using the @Binary@ instances here to avoid issues with
 -- overlapping instances as the install plan will involve two different versions

--- a/vector-binary-instances.cabal
+++ b/vector-binary-instances.cabal
@@ -51,7 +51,7 @@ Library
   Build-depends:
     base > 3 && < 4.10,
     vector >= 0.6 && < 0.12,
-    binary >= 0.7 && < 0.9
+    binary >= 0.5 && < 0.9
 
 Benchmark benchmarks
   Type:           exitcode-stdio-1.0
@@ -62,7 +62,8 @@ Benchmark benchmarks
     vector,
     bytestring,
     binary,
-    criterion
+    criterion,
+    deepseq
   hs-source-dirs: benchmarks
 
 Test-Suite tests


### PR DESCRIPTION
Currently, building `criterion` with GHC 7.4.2 is a bit annoying because the current version of this package requires `binary >= 0.7`, which is more recent than the version of `binary` (0.5) that is bundled with GHC 7.4.2. But `vector-binary-instances` doesn't seem to make use of any recent `binary` features in the first place, so this lower bound is easy to relax.

I had to patch up the benchmarks a bit to accommodate GHC 7.4.2's old bundled version of `deepseq`, but it's not too invasive.