### PR TITLE
Allow building with base-4.11

### DIFF
--- a/vector-binary-instances.cabal
+++ b/vector-binary-instances.cabal
@@ -50,7 +50,7 @@ Library
 
   -- Packages needed in order to build this package.
   Build-depends:
-    base > 3 && < 4.11,
+    base > 3 && < 4.12,
     vector >= 0.6 && < 0.13,
     binary >= 0.5 && < 0.10
 


### PR DESCRIPTION
Allowing `vector-binary-instances` to be built with GHC 8.4.1.