### PR TITLE
Support GHC 9.0 by bumping bounds and switching to tasty-bench.

### DIFF
--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -3,7 +3,7 @@
 import Data.Binary
 import Data.Binary.Get
 import Data.Binary.Put
-import Gauge.Main
+import Test.Tasty.Bench
 
 import qualified Data.ByteString.Lazy     as BS
 import qualified Data.Vector.Unboxed as U

--- a/vector-binary-instances.cabal
+++ b/vector-binary-instances.cabal
@@ -53,7 +53,7 @@ Library
 
   -- Packages needed in order to build this package.
   Build-depends:
-    base > 3 && < 4.15,
+    base > 3 && < 4.16,
     vector >= 0.6 && < 0.13,
     binary >= 0.5 && < 0.11
 
@@ -66,7 +66,7 @@ Benchmark benchmarks
     vector,
     bytestring,
     binary,
-    gauge,
+    tasty-bench,
     deepseq
   hs-source-dirs: benchmarks
 


### PR DESCRIPTION
Fixes #21.